### PR TITLE
License repo under BSD 3-Clause License

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2022, Luis M. Torres-Villegas
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
## Why

When I created the repo, I was naive enough to license under the Unlicense.

But then I came to depend on:

1. `pick` for the GUI (see his [MIT License](https://github.com/wong2/pick/blob/master/LICENSE))
2. `networkx` for Dijkstra's algorithm (see their [BSD 3-Clause License](https://github.com/networkx/networkx/blob/main/LICENSE.txt))

And I realized my license would have to comply with theirs.

See [this SO question](https://opensource.stackexchange.com/questions/9326/what-are-the-license-obligations-if-just-importing-licensed-code-without-modifyi) for more context. Note that I am clueless as to the legal correctness of that answer.

## Changes

- Add the LICENSE.md (`.md` so that it renders nicely, since `.txt` does not)

## Issues

Resolves #33

## Disclaimer

I Am Not A Lawyer.

Please forgive me if I didn't get this license thing right. :trollface: